### PR TITLE
Fix some information pertaining to the spawn chunk glitch

### DIFF
--- a/Chapter 1 - The Original Far Lands/Part 1.5 - Moving the Far Lands to Spawn.md
+++ b/Chapter 1 - The Original Far Lands/Part 1.5 - Moving the Far Lands to Spawn.md
@@ -1,4 +1,4 @@
-There's a bug in beta 1.7.3 where at every power of 2 past 2^25, some chunks from spawn will be ported to the far lands. This is the only instance where trees can generate past 3.2E7 (without removing the fake chunks).
+There's a bug in beta 1.7.3 where at every power of 2 past 2^19, some chunks from spawn will be ported all the way out to said dishance. Notably, this still works for 2^24, which is in the far lands, and 2^25, which is beyond the 32 million fake chunk boundary. This is the only instance where trees can generate past 3.2E7 (without patching the fake chunks).
 
 For example, when the x-axis and the z-axis are both equal to 2^25, the far lands give away to the terrain seen at spawn.
 

--- a/Chapter 1 - The Original Far Lands/Part 1.5 - Moving the Far Lands to Spawn.md
+++ b/Chapter 1 - The Original Far Lands/Part 1.5 - Moving the Far Lands to Spawn.md
@@ -1,4 +1,4 @@
-There's a bug in beta 1.7.3 where at every power of 2 past 2^19, some chunks from spawn will be ported all the way out to said distance. Notably, this still works for 2^24, which is in the far lands, and powers of two 2^25 and beyond, which are beyond the 32 million fake chunk boundary. This is the only instance where trees can generate past 3.2E7 (without patching the fake chunks).
+There's a bug in beta 1.7.3 where at every power of 2 past 2^19, some chunks from spawn will be ported all the way out to said distance. Notably, this still works for 2^24, which is in the far lands, and powers of two 2^25 and above, which are beyond the 32 million fake chunk boundary. This is the only instance where terrain features such as trees and ore veins can generate past 3.2E7 (without patching the fake chunks).
 
 For example, when the x-axis and the z-axis are both equal to 2^25, the far lands give away to the terrain seen at spawn.
 

--- a/Chapter 1 - The Original Far Lands/Part 1.5 - Moving the Far Lands to Spawn.md
+++ b/Chapter 1 - The Original Far Lands/Part 1.5 - Moving the Far Lands to Spawn.md
@@ -1,4 +1,4 @@
-There's a bug in beta 1.7.3 where at every power of 2 past 2^19, some chunks from spawn will be ported all the way out to said dishance. Notably, this still works for 2^24, which is in the far lands, and 2^25, which is beyond the 32 million fake chunk boundary. This is the only instance where trees can generate past 3.2E7 (without patching the fake chunks).
+There's a bug in beta 1.7.3 where at every power of 2 past 2^19, some chunks from spawn will be ported all the way out to said distance. Notably, this still works for 2^24, which is in the far lands, and powers of two 2^25 and beyond, which are beyond the 32 million fake chunk boundary. This is the only instance where trees can generate past 3.2E7 (without patching the fake chunks).
 
 For example, when the x-axis and the z-axis are both equal to 2^25, the far lands give away to the terrain seen at spawn.
 

--- a/Chapter 2 - The Far Lands in 1.12.2/Part 2.5 - Shifting the Far Lands.md
+++ b/Chapter 2 - The Far Lands in 1.12.2/Part 2.5 - Shifting the Far Lands.md
@@ -8,7 +8,7 @@ The same may be done for ChunkGeneratorHell and ChunkGeneratorEnd in order to of
 
 ![MoveFL2](https://raw.githubusercontent.com/ThisTestUser/FarLandsChronicles/master/assets/Ch2/MoveFL2.png)
 
-For the overworld, you should also mod populate(), in order allow the terrain features to generate properly. Note that some features (like ores) use both chunk coordinates and block coordinates, so you will see a subtle difference when comparing against the original terrain.
+For the overworld, you should also mod populate(), in order to allow the terrain features to generate properly. Note that some features (like ores) use both chunk coordinates and block coordinates, so you will see a subtle difference when comparing against the original terrain.
 
 ![MoveFL3](https://raw.githubusercontent.com/ThisTestUser/FarLandsChronicles/master/assets/Ch2/MoveFL3.png)
 

--- a/Chapter 3 - The Far Lands in Mods/Part 0 - Setting Up.md
+++ b/Chapter 3 - The Far Lands in Mods/Part 0 - Setting Up.md
@@ -10,7 +10,7 @@ We're about to see what the far lands looks like, modded. Here are the mods we a
 * GalacticraftCore-1.12.2-4.0.2.238, Galacticraft-Planets-1.12.2-4.0.2.238, MicdoodleCore-1.12.2-4.0.2.238
 * twilightforest-1.12.2-3.10.1013-universal
 
-Note: The GalacticCraft addons present are ExtraPlanets-1.12.2-0.5.8 and More-Planets-1.12.2-2.0.22-GC238.
+Note: The Galacticraft addons present are ExtraPlanets-1.12.2-0.5.8 and More-Planets-1.12.2-2.0.22-GC238.
 
 These mods were not designed to work in the far lands, and some of them have to be modded. We will be using JByteMod and Recaf to add in try-catch blocks or delete instructions.
 
@@ -36,7 +36,7 @@ Now, open up Recaf and navigate to the method. Open the try-catches, and add an 
 
 ![TheBetweenlandsMod1](https://raw.githubusercontent.com/ThisTestUser/FarLandsChronicles/master/assets/Ch3/TheBetweenlandsMod1.png)
 
-For the GalacticCraft core mod, you need to change an athrow to a pop at micdoodle8\mods\galacticraft\api\prefab\world\gen\BiomeDecoratorSpace.class decorate().
+For the Galacticraft core mod, you need to change an athrow to a pop at micdoodle8\mods\galacticraft\api\prefab\world\gen\BiomeDecoratorSpace.class decorate().
 
 ![GalCraftMod](https://raw.githubusercontent.com/ThisTestUser/FarLandsChronicles/master/assets/Ch3/GalCraftMod.png)
 

--- a/Chapter 3 - The Far Lands in Mods/Part 1 - Gallery.md
+++ b/Chapter 3 - The Far Lands in Mods/Part 1 - Gallery.md
@@ -68,7 +68,7 @@ Unlike other mods, Twilight Forest's far lands stop at 128 blocks. Many structur
 
 ![Twilight2](https://raw.githubusercontent.com/ThisTestUser/FarLandsChronicles/master/assets/Ch3/Twilight2.png)
 
-GalaticCraft has a lot of dimensions, so we're not going to explore them all. Some dimensions don't generate far lands, due to them having different terrain generators. Warning: Some of these dimensions may cause crashes when visiting the far lands.
+Galacticraft has a lot of dimensions, so we're not going to explore them all. Some dimensions don't generate far lands, due to them having different terrain generators. Warning: Some of these dimensions may cause crashes when visiting the far lands.
 
 ![GalCraft](https://raw.githubusercontent.com/ThisTestUser/FarLandsChronicles/master/assets/Ch3/GalCraft.png)
 


### PR DESCRIPTION
From my own testing, as well as AntVenom's video on the matter (https://youtu.be/ZZx5_vTGkus), this effect starts as early as 524,288 blocks, and from my tests first affected Beta 1.6 Test Build 3.